### PR TITLE
Add support to DTM data type (Fixes #7)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@
 .. image:: https://coveralls.io/repos/github/c0fec0de/pyebus/badge.svg
     :target: https://coveralls.io/github/c0fec0de/pyebus
 
-.. image:: https://readthedocs.org/projects/pyebus/badge/?version=1.5.0
-    :target: https://pyebus.readthedocs.io/en/1.5.0/?badge=1.5.0
+.. image:: https://readthedocs.org/projects/pyebus/badge/?version=1.5.1
+    :target: https://pyebus.readthedocs.io/en/1.5.1/?badge=1.5.1
 
 .. image:: https://img.shields.io/pypi/pyversions/pyebus.svg
    :target: https://pypi.python.org/pypi/pyebus

--- a/pyebus/typedecoder.py
+++ b/pyebus/typedecoder.py
@@ -11,11 +11,13 @@ TYPEMAP = {
     # HDA       hex date                      dd.mm.yyyy               day first, including weekday, Sunday=0x07
     # HDA:3     hex date                      dd.mm.yyyy               day first, excluding weekday
     # DAY       date in days                  dd.mm.yyyy               days since 01.01.1900
+    # DTM       date with minutes             dd.mm.yyyy hh:mm         date+time in minutes since 01.01.2009
     "BDA": types.DateType(),
     "BDA:3": types.DateType(),
     "HDA": types.DateType(),
     "HDA:3": types.DateType(),
     "DAY": types.DateType(),
+    "DTM": types.DateTimeType(),
     # BTI       BCD time                      hh:mm:ss                 seconds first
     # HTI       hex time                      hh:mm:ss                 hours first
     # VTI       hex time                      hh:mm:ss                 seconds first
@@ -135,6 +137,8 @@ def decode_type(typecode, divider=None):
     DateType()
     >>> decode_type("DAY")
     DateType()
+    >>> decode_type("DTM")
+    DateTimeType()
     >>> decode_type("BTI")
     TimeType()
     >>> decode_type("HTI")

--- a/pyebus/types.py
+++ b/pyebus/types.py
@@ -776,15 +776,15 @@ class DateTimeType(Type):
     >>> t
     DateTimeType()
     >>> t.comment
-    'DAY.MONTH.YEAR HOUR:MINUTE:SECOND'
-    >>> t.decode('30.12.2020 23:59:59')
-    DateTime(2020, 12, 30, 23, 59, 59)
+    'DAY.MONTH.YEAR HOUR:MINUTE'
+    >>> t.decode('30.12.2020 23:59')
+    DateTime(2020, 12, 30, 23, 59)
     >>> t.decode('-.-.- -:-:-') is None
     True
-    >>> t.encode('30.12.2020 23:59:59')
-    '30.12.2020 23:59:59'
-    >>> t.encode(DateTime(2020, 12, 30, 23, 59, 59))
-    '30.12.2020 23:59:59'
+    >>> t.encode('30.12.2020 23:59')
+    '30.12.2020 23:59'
+    >>> t.encode(DateTime(2020, 12, 30, 23, 59))
+    '30.12.2020 23:59'
     >>> t.encode(None)
     '-.-.- -:-:-'
     """
@@ -794,21 +794,21 @@ class DateTimeType(Type):
     def decode(self, value):
         """Decode `value`."""
         if value != self._NONE:
-            return DateTime.strptime(value, "%d.%m.%Y %H:%M:%S")
+            return DateTime.strptime(value, "%d.%m.%Y %H:%M")
         return None
 
     def encode(self, value):
         """Encode `value`."""
         if isinstance(value, str):
-            value = DateTime.strptime(value, "%d.%m.%Y %H:%M:%S")
+            value = DateTime.strptime(value, "%d.%m.%Y %H:%M")
         if value is not None:
-            return f"{value.day}.{value.month}.{value.year} {value.hour:02d}:{value.minute:02d}:{value.second:02d}"
+            return f"{value.day}.{value.month}.{value.year} {value.hour:02d}:{value.minute:02d}"
         return self._NONE
 
     @property
     def comment(self):
         """Get Comment on allowed values."""
-        return "DAY.MONTH.YEAR HOUR:MINUTE:SECOND"
+        return "DAY.MONTH.YEAR HOUR:MINUTE"
 
 
 class WeekdayType(Type):
@@ -871,15 +871,15 @@ class DateTime(datetime.datetime):
     """
     DateTime.
 
-    >>> t = DateTime(2020, 12, 31, 23, 59, 59)
+    >>> t = DateTime(2020, 12, 31, 23, 59)
     >>> t
-    DateTime(2020, 12, 31, 23, 59, 59)
+    DateTime(2020, 12, 31, 23, 59)
     >>> str(t)
-    '31.12.2020 23:59:59'
+    '31.12.2020 23:59'
     """
 
     def __str__(self):
-        return self.strftime("%d.%m.%Y %H:%M:%S")
+        return self.strftime("%d.%m.%Y %H:%M")
 
 
 class Time(datetime.time):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyebus"
-version = "1.5.0"
+version = "1.5.1"
 description = "Pythonic Interface to EBUS Daemon (ebusd)"
 authors = [
   "c0fec0de <c0fec0de@gmail.com>"


### PR DESCRIPTION
Add support to DTM data type.

Date with minutes (`dd.mm.yyyy hh:mm`), used in schedulers.

Fixes #7.